### PR TITLE
Rewrite Install.sh

### DIFF
--- a/Install.sh
+++ b/Install.sh
@@ -1,76 +1,65 @@
-  GNU nano 4.8                                                                                       Install.sh                                                                                        Modified
-##!/bin/bash
+#!/bin/bash
+
+if [ $(id -u) -ne 0 ]; then
+    echo -e "\e[31mThis must be run as root!\e[0m"
+    exit 126
+fi
+
 echo "You are about to download and install the required items for HP ILO4 fan control."
-echo "Do you accept? [yes] or [no] :"
-read input
-if [ $input = yes ] ; then
-# agreement confirmed
-# refresh OR create agreement file status
-        echo "Installing required apt packages; sshpass, lm-sensors, and wget"
-        apt install sshpass wget lm-sensors jq -y
-        echo "Installed required apt packages"
-        cd /
-        echo "Downloading ILO_250 for ROM upgrade to the / directory."
-        wget https://github.com/That-Guy-Jack/HP-ILO-Fan-Control/tree/main/Files/ilo_250
-        echo "Download finished!"
-        echo "Making autofan.service"
-        cd /etc/systemd/system/
-        wget https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan.service
-        echo "Finished making autofan.service"
-        echo "Is Your host based on EXSI? (uses ILO temps over lm-sensors) [Y]/[N]"
-        read exsi
-        if [ $exsi = Y ] 
-                echo "Which server are you running? DL360p G8 (1) or DL380p G8 (2) [1] or [2] :"
-                        read server
-                        if [ $server = 1 ] ; then
-                                echo "Preping autofan.sh for DL360p G8"
-                                cd /
-                                echo "Downloading latest autofan.sh"
-                                wget https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan-dl360p-g8-EXSI.sh
-                                echo "Downloaded autofan.sh, please change the placeholders with correct info"
-                                echo "Please cisit the GitHub page to follow the instructions!"
-                                echo "https://github.com/That-Guy-Jack/HP-ILO-Fan-Control"
-                                exit 1
-                        elif [ $server = 2 ] ; then
-                                echo "Preping autofan.sh for DL380p G8"
-                                cd /
-                                echo "Downloading latest autofan.sh for DL380p G8"
-                                wget https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan-dl380p-g8-EXSI.sh
-                                echo "Renaming file"
-                                mv autofan-dl380p-g8.sh autofan.sh
-                                echo "Downloaded autofan.sh, please change the placeholders with correct info"
-                                echo "Please cisit the GitHub page to follow the instructions!"
-                                echo "https://github.com/That-Guy-Jack/HP-ILO-Fan-Control"
-                                exit 1
-                        fi
-                        else
-                        echo " :( exitting"
-                        exit 1
-        else
-        echo "Which server are you running? DL360p G8 (1) or DL380p G8 (2) [1] or [2] :"
-                read server
-                if [ $server = 1 ] ; then
-                        echo "Preping autofan.sh for DL360p G8"
-                        cd /
-                        echo "Downloading latest autofan.sh"
-                        wget https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan.sh
-                        echo "Downloaded autofan.sh, please change the placeholders with correct info"
-                        echo "Please cisit the GitHub page to follow the instructions!"
-                        echo "https://github.com/That-Guy-Jack/HP-ILO-Fan-Control"
-                        exit 1
-                elif [ $server = 2 ] ; then
-                        echo "Preping autofan.sh for DL380p G8"
-                        cd /
-                        echo "Downloading latest autofan.sh"
-                        wget https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan-dl380p-g8.sh
-                        echo "Renaming file"
-                        mv autofan-dl380p-g8.sh autofan.sh
-                        echo "Downloaded autofan.sh, please change the placeholders with correct info"
-                        echo "Please cisit the GitHub page to follow the instructions!"
-                        echo "https://github.com/That-Guy-Jack/HP-ILO-Fan-Control"
-                        exit 1
-                fi
-                else
-                echo " :( exitting"
-                exit 1
+read -rep "Do you accept? (y/N): " ACCEPTED
+if [[ ${ACCEPTED,,} =~ ^[y] ]]; then
+    mkdir -p ~/autofan
+    cd ~/autofan
+    echo "Installing required packages..."
+    apt install sshpass wget lm-sensors jq -y
+    echo -e "\e[92mDownloading ILO_250 for ROM upgrade\e[0m"
+    wget -q https://github.com/That-Guy-Jack/HP-ILO-Fan-Control/tree/main/Files/ilo_250
+    echo -e "\e[92m Creating autofan service\e[0m"
+    wget -q https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/autofan.service
+    mv autofan.service /etc/systemd/system/
+    echo -e "\e[92m autofan service created\e[0m"
+    read -rep $'Which server are you running? (Enter 1-4)
+    1. DL360p G8 (No ESXi)
+    2. DL380p G8 (no ESXi)
+    3. DL360p G8 (ESXi-based)
+    4. DL380p G8 (ESXi-based)\n' HOSTCHOICE
+    case $HOSTCHOICE in
+    1)
+        AUTOFANFILE="autofan.sh"
+        HOSTTYPE="DL360p G8 (No ESXi)"
+        ;;
+    2)
+        AUTOFANFILE="autofan-dl380p-g8.sh"
+        HOSTTYPE="DL380p G8 (No ESXi)"
+        ;;
+    3)
+        AUTOFANFILE="autofan-dl360p-g8-EXSI.sh"
+        HOSTTYPE="DL360p G8 (ESXi-based)"
+        ;;
+    4)
+        AUTOFANFILE="autofan-dl380p-g8-EXSI.sh"
+        HOSTTYPE="DL370p G8 (ESXi-based)"
+        ;;
+    *)
+        echo -e "\e[31mInvalid choice. Exiting.\e[0m"
+        exit 1
+        ;;
+    esac
+
+    echo "Preping autofan.sh for $HOSTTYPE"
+    echo "Downloading latest autofan.sh"
+    wget -q https://raw.githubusercontent.com/That-Guy-Jack/HP-ILO-Fan-Control/main/Files/$AUTOFANFILE -O autofan.sh
+    read -rep 'Enter iLO Username: ' ILOUSERNAME
+    read -rep 'Enter iLO Password: ' ILOPASSWORD
+    read -rep 'Enter iLO IP/hostname: ' ILOHOST
+    sed -ri "s/your username/$ILOUSERNAME/" autofan.sh
+    sed -ri "s/your password/$ILOPASSWORD/" autofan.sh
+    sed -ri "s/your ilo ip/$ILOHOST/" autofan.sh
+    mv autofan.sh /
+
+    echo -e "\e[92mDone! Please visit the GitHub page to follow the instructions!\e[0m"
+    echo -e "\e[1\https://github.com/That-Guy-Jack/HP-ILO-Fan-Control\e[0m"
+else
+    echo -e "\e[31m:( exiting\e[0m"
+    exit 0
 fi


### PR DESCRIPTION
Install.sh had some errors (the first couple lines were part of nano, and it was failing at one of the else statements), so I ended up rewriting the whole script. It does a few things differently:

1. Prompts for iLO creds and automatically puts them in the file
2. Puts the files in ~ to begin with, and then moves them to the appropriate places. This is probably not necessary, but it feels a little safer than doing it in / 
3. Instead of asking for the server type and then if it's ESXi, it just gives four options. This was mostly to reduce the number of nested if statements. 
4. Colors, because why not? 

I _believe_ it does everything that the original one did, but let me know if I missed anything and I can add it!